### PR TITLE
fix(lomiri-schemas): revert remove feature

### DIFF
--- a/anda/others/lomiri-schemas/lomiri-schemas.spec
+++ b/anda/others/lomiri-schemas/lomiri-schemas.spec
@@ -9,7 +9,6 @@ Summary:    Configuration schemas for lomiri
 License:    LGPL-2.0-or-later
 URL:        https://gitlab.com/ubports/development/core/lomiri-schemas
 Source0:    %url/-/archive/%commit/lomiri-schemas-%commit.tar.gz
-Patch0:     https://gitlab.com/cat-master21/lomiri-schemas/-/commit/e32de385c858f9096c6014a3749117fa6f94f231.patch
 BuildArch:  noarch
 
 BuildRequires: cmake
@@ -22,7 +21,7 @@ BuildRequires: intltool
 Configuration schemas for lomiri desktop enviroment.
 
 %prep
-%autosetup -n %{name}-%commit -p1
+%autosetup -n %{name}-%commit
 
 %build
 %cmake -DCMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT=true


### PR DESCRIPTION
For some reason, in my personal computer (Fedora 37), the schemas compile fine without the patch and with it fail but in my VM (also Fedora 37) it fails without the patch (opposite of my computer). So **Please** test this before merge.